### PR TITLE
feat: Add summary artifact to bundle updating

### DIFF
--- a/.github/workflows/discord-webhook-sender.yml
+++ b/.github/workflows/discord-webhook-sender.yml
@@ -23,6 +23,19 @@ jobs:
           download_path: 'ReVanced-Patch-Bundles'
           download_filename: 'changed_files.zip'
 
+      - name: Download Summary Artifact from Patch bundle updater
+        id: download_patch_bundle_summary_artifact
+        uses: benday-inc/download-latest-artifact@main
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
+          repository_owner: 'Jman-Github'
+          repository_name: 'ReVanced-Patch-Bundles'
+          branch_name: 'bundles'
+          artifact_name: 'updated_bundles'
+          workflow_name: 'Patch bundle updater'
+          download_path: 'ReVanced-Patch-Bundles'
+          download_filename: 'updated-bundles.zip'
+
       - name: Download Artifact from Commit puller
         id: download_commit_puller_artifact
         uses: benday-inc/download-latest-artifact@main
@@ -44,6 +57,9 @@ jobs:
 
       - name: Unzip Patch bundle updater artifact
         run: unzip ReVanced-Patch-Bundles/changed_files.zip -d ReVanced-Patch-Bundles/patch_bundle_updater_artifact
+
+      - name: Unzip Summary artifact
+        run: unzip ReVanced-Patch-Bundles/updated-bundles.zip -d ReVanced-Patch-Bundles/patch_bundle_updater_artifact
 
       - name: Unzip Commit puller artifact
         run: unzip ReVanced-Patch-Bundles/commit-link.zip -d ReVanced-Patch-Bundles/commit_puller_artifact
@@ -68,6 +84,12 @@ jobs:
           changes_json+="]"
           echo "::set-output name=changes_json::$changes_json"
 
+          summary=$(cat ReVanced-Patch-Bundles/patch_bundle_updater_artifact/updated-bundles.txt)
+          if [ -z "$summary" ]; then
+            summary="{}"
+          fi
+          echo "::set-output name=summary::${summary}"
+
           commit_link=$(cat ReVanced-Patch-Bundles/commit_puller_artifact/commit-link.txt)
           
           if [ -z "$commit_link" ]; then
@@ -87,6 +109,10 @@ jobs:
             **Changes:**
             ```
             ${{ join(fromJson(steps.set_changes.outputs.changes_json), '') }}
+            ```
+            **Summary:**
+            ```
+            ${{ steps.set_changes.outputs.summary }}
             ```
             ${{ steps.set_changes.outputs.commit_link }}
             

--- a/.github/workflows/patch-bundle-updater.yml
+++ b/.github/workflows/patch-bundle-updater.yml
@@ -80,6 +80,11 @@ jobs:
             echo "changed_files=changed_files.txt" >> $GITHUB_ENV
           fi
 
+      - name: Build summary of updated bundles
+        if: env.has_changes == 'true' && env.changed_files != ''
+        run: |
+          python build_summary.py
+
       - name: Push changes
         if: env.has_changes == 'true'
         uses: ad-m/github-push-action@master
@@ -93,3 +98,10 @@ jobs:
         with:
           name: changed_files
           path: changed_files.txt
+
+      - name: Create artifact of updated bundles
+        if: env.has_changes == 'true' && env.changed_files != ''
+        uses: actions/upload-artifact@main
+        with:
+          name: updated_bundles
+          path: updated-bundles.txt

--- a/build_summary.py
+++ b/build_summary.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+
+def main():
+    summary = {}
+    changed_path = Path('changed_files.txt')
+    if not changed_path.is_file():
+        print('changed_files.txt not found')
+        return
+
+    for line in changed_path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        file_path = Path(line)
+        if not file_path.is_file():
+            print(f'File not found: {line}')
+            continue
+        try:
+            with open(file_path) as f:
+                data = json.load(f)
+        except Exception as e:
+            print(f'Failed to load {line}: {e}')
+            continue
+        version = None
+        if isinstance(data, dict):
+            if 'version' in data:
+                version = data['version']
+            elif 'patches' in data and isinstance(data['patches'], dict):
+                version = data['patches'].get('version')
+        if version:
+            bundle_name = file_path.stem.replace('-patches-bundle', '')
+            summary[bundle_name] = version
+
+    with open('updated-bundles.txt', 'w') as f:
+        json.dump(summary, f, indent=2)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `build_summary.py`
- add bundle change summary artifact
- ensure patch-bundle-updater workflow ends with newline
- extend discord-webhook-sender workflow to download `updated_bundles` artifact
- include bundle summary in the Discord message