### PR TITLE
fix: Discord webhook summary output

### DIFF
--- a/build_summary.py
+++ b/build_summary.py
@@ -34,8 +34,8 @@ def main():
             summary[bundle_name] = version
 
     with open('updated-bundles.txt', 'w') as f:
-        json.dump(summary, f, indent=2)
-    print(json.dumps(summary, indent=2))
+        json.dump(summary, f, separators=(",", ":"))
+    print(json.dumps(summary, separators=(",", ":")))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- ensure the summary output is a single-line JSON string so the Discord webhook displays it correctly