### PR TITLE
Fix: bundle workflow updater auth failure

### DIFF
--- a/.github/workflows/patch-bundle-updater.yml
+++ b/.github/workflows/patch-bundle-updater.yml
@@ -40,22 +40,15 @@ jobs:
           source venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install requests httpx
-          output=$(python generate_bundles.py 2>&1)
-          echo "$output"
-          if echo "$output" | grep -q "Your branch is up to date with 'origin/bundles'."; then
-            echo "Branch is up to date with 'origin/bundles'. Exiting..."
-            echo "cancel_workflow=true" >> $GITHUB_ENV
-            echo "has_changes=false" >> $GITHUB_ENV
+          python generate_bundles.py
+          git add '*.json'
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m 'feat: `patch-bundles` update'
+            git push origin HEAD:${{ github.ref }} --follow-tags
+            echo "has_changes=true" >> $GITHUB_ENV
           else
-            git add '*.json'
-            if [ -n "$(git status --porcelain)" ]; then
-              git commit -m "feat: `patch-bundles` update"
-              git push origin HEAD:${{ github.ref }} --follow-tags
-              echo "has_changes=true" >> $GITHUB_ENV
-            else
-              echo "No changes to commit. Exiting..."
-              echo "has_changes=false" >> $GITHUB_ENV
-            fi
+            echo "No changes to commit. Exiting..."
+            echo "has_changes=false" >> $GITHUB_ENV
           fi
         working-directory: ${{ github.workspace }}
         continue-on-error: true

--- a/generate_bundles.py
+++ b/generate_bundles.py
@@ -177,7 +177,8 @@ async def main():
         subprocess.run(["git", "config", "user.email", "41898282+github-actions[bot]@users.noreply.github.com"], check=True)
         subprocess.run(["git", "config", "user.name", "github-actions[bot]"], check=True)
 
-        subprocess.run(["git", "pull", "origin", "bundles"], check=True)
+        # The calling workflow already checks out the latest commits.
+        # Avoid pulling here to prevent authentication issues in CI.
 
         tasks = [fetch_release_data(source, repo) for source, repo in sources.items()]
         results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -186,20 +187,8 @@ async def main():
             if isinstance(result, Exception):
                 print(f"Task for {source} failed: {result}")
         
-        status_result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            stdout=subprocess.PIPE,
-            text=True,
-            check=True,
-        )
-
-        if status_result.stdout.strip():
-            subprocess.run(
-                ["git", "commit", "-m", "feat: `patch-bundles` update"],
-                check=True,
-            )
-        else:
-            print("No changes detected. Skipping commit.")
+        # Let the calling workflow handle committing and pushing any staged
+        # changes. This script only stages modified bundle files.
     except subprocess.CalledProcessError as e:
         print(f"Subprocess failed: {e}")
     except Exception as e:


### PR DESCRIPTION
## Summary
- avoid pulling remote in `generate_bundles.py`
- simplify bundle updater workflow and rely on git status for changes