### PR TITLE
fix: manager update workflow branch handling

### DIFF
--- a/.github/workflows/manager-update-checker.yml
+++ b/.github/workflows/manager-update-checker.yml
@@ -60,6 +60,7 @@ jobs:
           python check_readme.py ${{ steps.get_artifact.outputs.artifact_url }}
         env:
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+          TARGET_BRANCH: bundles
 
       - name: Update README
         if: steps.check_readme.outputs.needs_update == 'true'
@@ -68,6 +69,7 @@ jobs:
         env:
           GITHUB_RUN_ID: ${{ github.run_id }}
           GIT_TOKEN: ${{ secrets.GIT_TOKEN }}
+          TARGET_BRANCH: bundles
 
       - name: Send Discord Notification
         if: steps.check_readme.outputs.needs_update == 'true'

--- a/check_readme.py
+++ b/check_readme.py
@@ -8,7 +8,7 @@ def check_readme(artifact_url):
         "Authorization": f"Bearer {os.environ['GIT_TOKEN']}",
         "Content-Type": "application/json"
     }
-    branch = os.environ.get("GITHUB_REF_NAME", "bundles")
+    branch = os.environ.get("TARGET_BRANCH") or os.environ.get("GITHUB_REF_NAME", "bundles")
     response = requests.get(
         f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/contents/README.md",
         headers=headers,

--- a/update_readme.py
+++ b/update_readme.py
@@ -8,7 +8,7 @@ def update_readme(artifact_url):
         "Authorization": f"Bearer {os.environ['GIT_TOKEN']}",
         "Content-Type": "application/json"
     }
-    branch = os.environ.get("GITHUB_REF_NAME", "bundles")
+    branch = os.environ.get("TARGET_BRANCH") or os.environ.get("GITHUB_REF_NAME", "bundles")
     response = requests.get(
         f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/contents/README.md",
         headers=headers,


### PR DESCRIPTION
## Summary
- update `check_readme.py` to allow explicit branch via `TARGET_BRANCH`
- update `update_readme.py` to allow explicit branch via `TARGET_BRANCH`
- make the manager update workflow set `TARGET_BRANCH` so the scripts always operate on the `bundles` branch