### PR TITLE
Add hxreborn-tiktok stable and latest bundles

### DIFF
--- a/patch-bundles/bundle-sources.json
+++ b/patch-bundles/bundle-sources.json
@@ -729,6 +729,11 @@
         "patches": "https://api.github.com/repos/hxreborn/morphe-patches",
         "prerelease": false
     },
+    "hxreborn-tiktok-stable": {
+        "integration": "https://api.github.com/repos/revanced/revanced-integrations",
+        "patches": "https://api.github.com/repos/hxreborn/hxreborn-tiktok-patches",
+        "prerelease": false
+    },
     "ikura-stable": {
         "integration": "https://api.github.com/repos/revanced/revanced-integrations",
         "patches": "https://api.github.com/repos/Ikuradachi/ikura-patches",
@@ -2617,6 +2622,11 @@
     "hxreborn-latest": {
         "integration": "https://api.github.com/repos/revanced/revanced-integrations",
         "patches": "https://api.github.com/repos/hxreborn/morphe-patches",
+        "latest": true
+    },
+    "hxreborn-tiktok-latest": {
+        "integration": "https://api.github.com/repos/revanced/revanced-integrations",
+        "patches": "https://api.github.com/repos/hxreborn/hxreborn-tiktok-patches",
         "latest": true
     },
     "ikura-latest": {


### PR DESCRIPTION
Morphe patch bundle for TikTok 46.2.3. `validate_json.py` passes locally.

No `-dev` entry. The repo stopped publishing prereleases in v0.10.0, so `prerelease: true` would pin to an abandoned `v0.10.0-dev.1`.